### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,16 @@ node_js:
   - 4
   - 6
   - 7
+  - 14
+
+arch:
+  - amd64
+  - ppc64le
+  
+jobs:
+  exclude:
+    - arch: ppc64le
+      node_js: "0.12"
 
 notifications:
   email:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.